### PR TITLE
In dev, error explicitly with incompatible Node versions; change prepublish -> prepare

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,11 @@ Then open [`localhost:8000`](http://localhost:8000) in a browser.
 
 **NOTE:** The source code for the component is in `src`. A transpiled CommonJS version (generated with Babel) is available in `lib` for use with node.js, browserify and webpack. A UMD bundle is also built to `dist`, which can be included without the need for any build system.
 
+The build system requires Node 6. [It does not work in Node 8.][issue]
+
 To build, watch and serve the examples (which will also watch the component source), run `npm start`. If you just want to watch changes to `src` and rebuild `lib`, run `npm run watch` (this is useful if you are working with `npm link`).
+
+[issue]: https://github.com/JedWatson/react-component-gulp-tasks/issues/31
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "dependencies": {},
   "devDependencies": {
+    "check-node-version": "^3.2.0",
     "gulp": "^3.9.0",
     "react": "^15.0.0",
     "react-component-gulp-tasks": "^0.7.6",
@@ -30,11 +31,12 @@
     "react": "global:React"
   },
   "scripts": {
+    "depcheck": "check-node-version --node \">=6.0 <8.0\"",
     "build": "gulp clean && NODE_ENV=production gulp build",
     "examples": "gulp dev:server",
     "lint": "semistandard src/",
     "publish:site": "NODE_ENV=production gulp publish:examples",
-    "prepublish": "npm run build",
+    "prepare": "npm run depcheck && npm run build",
     "start": "gulp dev",
     "test": "echo \"no tests yet\" && exit 0",
     "watch": "gulp watch:lib"


### PR DESCRIPTION
Avoid this opaque error:

TypeError: require.extensions.hasOwnProperty is not a function

See https://github.com/mathisonian/react-editable-svg-label/issues/5