### PR TITLE
Upgrade rollup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5018,13 +5018,14 @@
       "dev": true
     },
     "rollup": {
-      "version": "0.68.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.68.2.tgz",
-      "integrity": "sha512-WgjNCXYv7ZbtStIap1+tz4pd2zwz0XYN//OILwEY6dINIFLVizK1iWdu+ZtUURL/OKnp8Lv2w8FBds8YihzX7Q==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.0.2.tgz",
+      "integrity": "sha512-FkkSrWUVo1WliS+/GIgEmKQPILubgVdBRTWampfdhkasxx7sM2nfwSfKiX3paIBVnN0HG3DvkTy13RfjkyBX9w==",
       "dev": true,
       "requires": {
         "@types/estree": "0.0.39",
-        "@types/node": "*"
+        "@types/node": "*",
+        "acorn": "^6.0.4"
       }
     },
     "rollup-plugin-alias": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "react": "^16.6.3",
     "react-dom": "^16.6.3",
     "react-portal": "^4.2.0",
-    "rollup": "^0.68.2",
+    "rollup": "^1.0.2",
     "rollup-plugin-alias": "^1.4.0",
     "rollup-plugin-babel": "^4.0.3",
     "rollup-plugin-cleaner": "^0.2.0",


### PR DESCRIPTION
This is emitting a couple warnings:

```
(!) cleaner plugin: The ongenerate hook used by plugin cleaner is deprecated. The generateBundle hook should be used instead.
(!) rollup-plugin-cpy plugin: The onwrite hook used by plugin rollup-plugin-cpy is deprecated. The generateBundle hook should be used instead.
```

I've reported them:

- saf33r/rollup-plugin-cleaner#5
- shrynx/rollup-plugin-cpy#4

They don't seem to be blocking.